### PR TITLE
started fixing logging

### DIFF
--- a/include/LightGBM/utils/log.h
+++ b/include/LightGBM/utils/log.h
@@ -83,8 +83,8 @@ class Log {
     vsprintf(str_buf, format, val);
 #endif
     va_end(val);
-    fprintf(stderr, "[LightGBM] [Fatal] %s\n", str_buf);
-    fflush(stderr);
+    // fprintf(stderr, "[LightGBM] [Fatal] %s\n", str_buf);
+    // fflush(stderr);
     throw std::runtime_error(std::string(str_buf));
   }
 

--- a/src/io/json11.cpp
+++ b/src/io/json11.cpp
@@ -21,7 +21,7 @@
 #include <LightGBM/json11.hpp>
 
 #include <limits>
-#include <cassert>
+// #include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -624,7 +624,7 @@ struct JsonParser final {
      * the input and return res. If not, flag an error.
      */
     Json expect(const string &expected, Json res) {
-        assert(i != 0);
+        // assert(i != 0);
         i--;
         if (str.compare(i, expected.length(), expected) == 0) {
             i += expected.length();


### PR DESCRIPTION
Trying to fix this issue

```
Note: information on .o files is not available
File ‘/Users/jlamb/repos/lgb-logging-thing/LightGBM/lightgbm.Rcheck/lightgbm/libs/lib_lightgbm.so’:
  Found ‘___assert_rtn’, possibly from ‘assert’ (C)
  Found ‘___stderrp’, possibly from ‘stderr’ (C)
  Found ‘___stdoutp’, possibly from ‘stdout’ (C)
  Found ‘_printf’, possibly from ‘printf’ (C)
  Found ‘_putchar’, possibly from ‘putchar’ (C)
  Found ‘_vprintf’, possibly from ‘vprintf’ (C)
File ‘lightgbm/libs/lib_lightgbm.so’:
  Found no calls to: ‘R_registerRoutines’, ‘R_useDynamicSymbols’

Compiled code should not call entry points which might terminate R nor
write to stdout/stderr instead of to the console, nor use Fortran I/O
nor system RNGs. The detected symbols are linked into the code but
might come from libraries and not actually be called.
It is good practice to register native routines and to disable symbol
search.

See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
* checking examples ... ERROR
Running examples in ‘lightgbm-Ex.R’ failed
The error most likely occurred in:
```

References:

* https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Printing
* ['not declared in this scope'](https://stackoverflow.com/questions/6283168/foo-was-not-declared-in-this-scope-c)
* https://github.com/dmlc/xgboost/blob/207f0587111a951f5cd6c609ade001587f242bd1/R-package/src/xgboost_R.h
* http://lists.r-forge.r-project.org/pipermail/rprotobuf-yada/2009-October/000022.html
* https://github.com/nimble-dev/nimble/pull/325/files